### PR TITLE
Add pass-based API key loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Simplify GitHub PR creation process using automation scripts and AI tools. Utili
    echo 'export GEMINI_API_KEY="your-gemini-api-key"' >> ~/.zshrc
    ```
 
+   You can also load keys from [pass](https://www.passwordstore.org/):
+   ```bash
+   export OPENAI_API_KEY=$(pass openai/key)
+   export GEMINI_API_KEY=$(pass gemini/key)
+   ```
+
 ## Usage
 
 ### Create PR

--- a/create_pr.sh
+++ b/create_pr.sh
@@ -56,9 +56,9 @@ if ! gh auth status &> /dev/null; then
 fi
 
 # Try to load OPENAI_API_KEY from pass if not already set
-if [ -z "$OPENAI_API_KEY" ] && command -v pass &> /dev/null; then
-    if pass show openai/key &> /dev/null; then
-        OPENAI_API_KEY=$(pass show openai/key)
+    api_key_from_pass=$(pass show openai/key 2>/dev/null)
+    if [ -n "$api_key_from_pass" ]; then
+        OPENAI_API_KEY="$api_key_from_pass"
     fi
 fi
 

--- a/create_pr.sh
+++ b/create_pr.sh
@@ -55,6 +55,13 @@ if ! gh auth status &> /dev/null; then
     gh auth login
 fi
 
+# Try to load OPENAI_API_KEY from pass if not already set
+if [ -z "$OPENAI_API_KEY" ] && command -v pass &> /dev/null; then
+    if pass show openai/key &> /dev/null; then
+        OPENAI_API_KEY=$(pass show openai/key)
+    fi
+fi
+
 # Check if OPENAI_API_KEY environment variable is set
 if [ -z "$OPENAI_API_KEY" ]; then
     echo "Warning: OPENAI_API_KEY environment variable is not set, AI title suggestions will not be available"

--- a/gemini_finder.sh
+++ b/gemini_finder.sh
@@ -10,10 +10,17 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
+# Try to load GEMINI_API_KEY from pass if not already set
+if [ -z "$GEMINI_API_KEY" ] && command -v pass &> /dev/null; then
+    if pass show gemini/key &> /dev/null; then
+        GEMINI_API_KEY=$(pass show gemini/key)
+    fi
+fi
+
 # Check if GEMINI_API_KEY exists
 if [ -z "$GEMINI_API_KEY" ]; then
     echo "Error: GEMINI_API_KEY is not set"
-    echo "Please set GEMINI_API_KEY in your ~/.zshrc"
+    echo "Please set GEMINI_API_KEY in your ~/.zshrc or password manager"
     exit 1
 fi
 

--- a/gemini_finder.sh
+++ b/gemini_finder.sh
@@ -11,9 +11,9 @@ if ! command -v gh &> /dev/null; then
 fi
 
 # Try to load GEMINI_API_KEY from pass if not already set
-if [ -z "$GEMINI_API_KEY" ] && command -v pass &> /dev/null; then
-    if pass show gemini/key &> /dev/null; then
-        GEMINI_API_KEY=$(pass show gemini/key)
+    api_key_from_pass=$(pass show gemini/key 2>/dev/null)
+    if [ -n "$api_key_from_pass" ]; then
+        GEMINI_API_KEY="$api_key_from_pass"
     fi
 fi
 

--- a/tw/README.md
+++ b/tw/README.md
@@ -42,6 +42,12 @@
    echo 'export GEMINI_API_KEY="你的 Gemini API Key"' >> ~/.zshrc
    ```
 
+   也可以使用 [pass](https://www.passwordstore.org/) 載入：
+   ```bash
+   export OPENAI_API_KEY=$(pass openai/key)
+   export GEMINI_API_KEY=$(pass gemini/key)
+   ```
+
 ## 使用方法
 
 ### 創建 PR

--- a/tw/create_pr.sh
+++ b/tw/create_pr.sh
@@ -54,6 +54,13 @@ if ! gh auth status &> /dev/null; then
     gh auth login
 fi
 
+# 如果尚未設置 OPENAI_API_KEY，嘗試從 pass 取得
+if [ -z "$OPENAI_API_KEY" ] && command -v pass &> /dev/null; then
+    if pass show openai/key &> /dev/null; then
+        OPENAI_API_KEY=$(pass show openai/key)
+    fi
+fi
+
 # 檢查是否設置了 OPENAI_API_KEY 環境變數
 if [ -z "$OPENAI_API_KEY" ]; then
     echo "警告: 未設置 OPENAI_API_KEY 環境變數，將無法使用 AI 生成標題建議"

--- a/tw/create_pr.sh
+++ b/tw/create_pr.sh
@@ -55,9 +55,9 @@ if ! gh auth status &> /dev/null; then
 fi
 
 # 如果尚未設置 OPENAI_API_KEY，嘗試從 pass 取得
-if [ -z "$OPENAI_API_KEY" ] && command -v pass &> /dev/null; then
-    if pass show openai/key &> /dev/null; then
-        OPENAI_API_KEY=$(pass show openai/key)
+    api_key_from_pass=$(pass show openai/key 2>/dev/null)
+    if [ -n "$api_key_from_pass" ]; then
+        OPENAI_API_KEY="$api_key_from_pass"
     fi
 fi
 

--- a/tw/gemini_finder.sh
+++ b/tw/gemini_finder.sh
@@ -10,10 +10,17 @@ if ! command -v gh &> /dev/null; then
     exit 1
 fi
 
+# 如果尚未設置 GEMINI_API_KEY，嘗試從 pass 取得
+if [ -z "$GEMINI_API_KEY" ] && command -v pass &> /dev/null; then
+    if pass show gemini/key &> /dev/null; then
+        GEMINI_API_KEY=$(pass show gemini/key)
+    fi
+fi
+
 # 檢查 GEMINI_API_KEY 是否存在
 if [ -z "$GEMINI_API_KEY" ]; then
     echo "錯誤: 未設置 GEMINI_API_KEY"
-    echo "請在 ~/.zshrc 中設置 GEMINI_API_KEY"
+    echo "請在 ~/.zshrc 或密碼管理器中設置 GEMINI_API_KEY"
     exit 1
 fi
 

--- a/tw/gemini_finder.sh
+++ b/tw/gemini_finder.sh
@@ -11,9 +11,9 @@ if ! command -v gh &> /dev/null; then
 fi
 
 # 如果尚未設置 GEMINI_API_KEY，嘗試從 pass 取得
-if [ -z "$GEMINI_API_KEY" ] && command -v pass &> /dev/null; then
-    if pass show gemini/key &> /dev/null; then
-        GEMINI_API_KEY=$(pass show gemini/key)
+    api_key_from_pass=$(pass show gemini/key 2>/dev/null)
+    if [ -n "$api_key_from_pass" ]; then
+        GEMINI_API_KEY="$api_key_from_pass"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- support loading `OPENAI_API_KEY` and `GEMINI_API_KEY` from `pass`
- document pass usage in both English and Chinese READMEs

## Testing
- `bash -n create_pr.sh gemini_finder.sh tw/create_pr.sh tw/gemini_finder.sh`

------
https://chatgpt.com/codex/tasks/task_e_684d0161a0a083218c378882d68ada45